### PR TITLE
Fix molecular formula regex

### DIFF
--- a/massql/msql.ebnf
+++ b/massql/msql.ebnf
@@ -153,7 +153,7 @@ divide: "/"
 plus: "+"
 minus: "-"
 
-moleculeformula: /[A-Z][A-Za-z1-9]*/
+moleculeformula: /[A-Z][A-Za-z0-9]*/
 aminoacids: /[A-Z][A-Z]*/
 peptide: /[A-Z][A-Z]*/
 peptidecharge: /[1-9]/


### PR DESCRIPTION
Fixes issue where formula with atom counts containing a zero result in parse error

for example:

Works:

https://massql.gnps2.org/parse?query=QUERY%20MS2DATA%20WHERE%20MS1MZ=formula(C1)

Doesn't work:

https://massql.gnps2.org/parse?query=QUERY%20MS2DATA%20WHERE%20MS1MZ=formula(C10)